### PR TITLE
Add default options object, add recursive cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "babel": "5.8.21",
     "eslint": "1.2.1",
     "eslint-config-gpbl": "1.0.2"
+  },
+  "dependencies": {
+    "recursive-readdir-sync": "1.0.6"
   }
 }

--- a/src/WebpackCleanupPlugin.js
+++ b/src/WebpackCleanupPlugin.js
@@ -1,6 +1,7 @@
 /* eslint no-console: 0 */
 
 import fs from "fs";
+import recursiveReadSync from "recursive-readdir-sync";
 
 class WebpackCleanupPlugin {
 
@@ -14,9 +15,11 @@ class WebpackCleanupPlugin {
 
     compiler.plugin("done", (stats) => {
       const { exclude=[] } = this.options;
+      // recursiveReadSync returns prefix of outputPath + "/"
+      const offset = outputPath.length + 1;
       const assets = stats.toJson().assets.map(asset => asset.name);
-
-      const files = fs.readdirSync(outputPath)
+      const files = recursiveReadSync(outputPath)
+        .map(path => path.substr(offset))
         .filter(file => exclude.indexOf(file) === -1 && assets.indexOf(file) === -1)
         .map(file => `${outputPath}/${file}`);
 

--- a/src/WebpackCleanupPlugin.js
+++ b/src/WebpackCleanupPlugin.js
@@ -4,7 +4,7 @@ import fs from "fs";
 
 class WebpackCleanupPlugin {
 
-  constructor(options) {
+  constructor(options = {}) {
     this.options = options;
   }
 


### PR DESCRIPTION
I submitted #1 and #2 issues, which were problems that I ran into when running the module.

My problems had come from:
- Not having an options object
- Using nested directories in my output

This pull request is two commits, one adds a default options object to the constructor in order to let the user omit it. The other adds a dependency on recursiveReadSync, another module that implements reading recursively. This module behaves slightly differently compared to readdir, as it returns absolute paths (basically, prefixed by outputPath). That requires an addition array map in order to strip the outputPath to match the format that is returned by webpack.

I ran `npm run lint` and made sure that that passed and also have build and tested this in my project, and it seems to work great. Let me know if there's anything blocking you from merging this and I'll help resolve any issues you might have.

Cheers,
Ted
