### PR TITLE
empty options will occur an Error

### DIFF
--- a/src/WebpackCleanupPlugin.js
+++ b/src/WebpackCleanupPlugin.js
@@ -14,7 +14,7 @@ class WebpackCleanupPlugin {
     const outputPath = compiler.options.output.path;
 
     compiler.plugin("done", (stats) => {
-      const { exclude=[] } = this.options;
+      const { exclude=[] } = this.options || {};
       // recursiveReadSync returns prefix of outputPath + "/"
       const offset = outputPath.length + 1;
       const assets = stats.toJson().assets.map(asset => asset.name);


### PR DESCRIPTION
`new WebpackCleanupPlugin()`
empty options will occur an Error,  
 this.options.exclude ---> TypeError: Cannot read property 'exclude' of undefined
