### PR TITLE
Do nothing if the target filesystem is not the default

### DIFF
--- a/src/WebpackCleanupPlugin.js
+++ b/src/WebpackCleanupPlugin.js
@@ -14,6 +14,9 @@ class WebpackCleanupPlugin {
     const outputPath = compiler.options.output.path;
 
     compiler.plugin("done", (stats) => {
+      if (compiler.outputFileSystem.constructor.name !== 'NodeOutputFileSystem')
+        return;
+
       const { exclude=[] } = this.options;
       // recursiveReadSync returns prefix of outputPath + "/"
       const offset = outputPath.length + 1;


### PR DESCRIPTION
Fix #7 by detecting a non-standard output file system and bailing out.
