### PR TITLE
Relative output path support

### DIFF
--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -3,13 +3,10 @@ import minimatch from 'minimatch';
 import path from 'path';
 
 export default function getFiles(fromPath, exclude = []) {
-  const files = recursiveReadSync(fromPath)
-    .map(p => p.substr(fromPath.length + 1)) // get files relative to fromPath
+  return recursiveReadSync(fromPath)
     .filter(file =>
       exclude.every(excluded =>
-        !minimatch(file, path.join(excluded), { dot: true })
+        !minimatch(path.relative(fromPath, file), path.join(excluded), { dot: true })
       )
-    )
-    .map(file => `${fromPath}/${file}`);
-  return files;
+    );
 }


### PR DESCRIPTION
This PR simplifies `getFiles` function and add support for relative output path in Webpack config, like so:

```
    output: {
        path: './build/'
    }
```

What do you think? Would it incorrectly affect something?