### PR TITLE
Fix cross-platform issues with getFiles()

### DIFF
--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -3,14 +3,14 @@ import minimatch from 'minimatch';
 import path from 'path';
 
 export default function getFiles(fromPath, exclude = []) {
-  fromPath = path.normalize(fromPath)
-  const files = recursiveReadSync(fromPath)
-    .map(p => p.substr(fromPath.length + 1)) // get files relative to fromPath
+  const npath = path.normalize(fromPath);
+  const files = recursiveReadSync(npath)
+    .map(p => p.substr(npath.length + 1)) // get files relative to fromPath
     .filter(file =>
       exclude.every(excluded =>
         !minimatch(file, path.join(excluded), { dot: true })
       )
     )
-    .map(file => path.join(fromPath, file));
+    .map(file => path.join(npath, file));
   return files;
 }

--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -3,6 +3,7 @@ import minimatch from 'minimatch';
 import path from 'path';
 
 export default function getFiles(fromPath, exclude = []) {
+  fromPath = path.normalize(fromPath)
   const files = recursiveReadSync(fromPath)
     .map(p => p.substr(fromPath.length + 1)) // get files relative to fromPath
     .filter(file =>
@@ -10,6 +11,6 @@ export default function getFiles(fromPath, exclude = []) {
         !minimatch(file, path.join(excluded), { dot: true })
       )
     )
-    .map(file => `${fromPath}/${file}`);
+    .map(file => path.join(fromPath, file));
   return files;
 }

--- a/test/WebpackCleanupPlugin.js
+++ b/test/WebpackCleanupPlugin.js
@@ -6,6 +6,8 @@ import { stub } from 'sinon';
 
 import WebpackCleanupPlugin from '../src/WebpackCleanupPlugin';
 
+const njoin = (x, y) => path.normalize(path.join(x, y))
+
 describe('WebpackCleanupPlugin', () => {
   it('should set options from constructor', () => {
     const plugin = new WebpackCleanupPlugin({ quiet: true, preview: true, exclude: ['a.txt'] });
@@ -33,11 +35,11 @@ describe('WebpackCleanupPlugin', () => {
         plugins: [new WebpackCleanupPlugin({ quiet: true })],
       });
       compiler.run(() => {
-        expect(unlinkSync).to.have.been.calledWith(`${outputPath}/a.txt`);
-        expect(unlinkSync).to.have.been.calledWith(`${outputPath}/b.txt`);
-        expect(unlinkSync).to.not.have.been.calledWith(`${outputPath}/bundle.js`);
-        expect(unlinkSync).to.have.been.calledWith(`${outputPath}/foo.json`);
-        expect(unlinkSync).to.have.been.calledWith(`${outputPath}/z.txt`);
+        expect(unlinkSync).to.have.been.calledWith(njoin(outputPath, 'a.txt'));
+        expect(unlinkSync).to.have.been.calledWith(njoin(outputPath, 'b.txt'));
+        expect(unlinkSync).to.not.have.been.calledWith(njoin(outputPath, 'bundle.js'));
+        expect(unlinkSync).to.have.been.calledWith(njoin(outputPath, 'foo.json'));
+        expect(unlinkSync).to.have.been.calledWith(njoin(outputPath, 'z.txt'));
         done();
       });
     });

--- a/test/getFiles.js
+++ b/test/getFiles.js
@@ -4,39 +4,52 @@ import getFiles from '../src/getFiles';
 
 const assetsPath = path.resolve(__dirname, 'assets');
 
+const njoin = (x, y) => path.normalize(path.join(x, y))
+
 describe('getFiles', () => {
   it('get recursively the files in the output path', () => {
     const files = getFiles(assetsPath);
     expect(files).to.have.length(7);
-    expect(files).to.include(`${assetsPath}/folder/p.txt`);
-    expect(files).to.include(`${assetsPath}/folder/q.txt`);
-    expect(files).to.include(`${assetsPath}/a.txt`);
-    expect(files).to.include(`${assetsPath}/b.txt`);
-    expect(files).to.include(`${assetsPath}/bundle.js`);
-    expect(files).to.include(`${assetsPath}/foo.json`);
-    expect(files).to.include(`${assetsPath}/z.txt`);
+    expect(files).to.include(njoin(assetsPath, 'folder/p.txt'));
+    expect(files).to.include(njoin(assetsPath, 'folder/q.txt'));
+    expect(files).to.include(njoin(assetsPath, 'a.txt'));
+    expect(files).to.include(njoin(assetsPath, 'b.txt'));
+    expect(files).to.include(njoin(assetsPath, 'bundle.js'));
+    expect(files).to.include(njoin(assetsPath, 'foo.json'));
+    expect(files).to.include(njoin(assetsPath, 'z.txt'));
+  });
+  it('get recursively the files in the relative path using POSIX separator', () => {
+    const files = getFiles('./test/assets');
+    expect(files).to.have.length(7);
+    expect(files).to.include(njoin('./test/assets', 'folder/p.txt'));
+    expect(files).to.include(njoin('./test/assets', 'folder/q.txt'));
+    expect(files).to.include(njoin('./test/assets', 'a.txt'));
+    expect(files).to.include(njoin('./test/assets', 'b.txt'));
+    expect(files).to.include(njoin('./test/assets', 'bundle.js'));
+    expect(files).to.include(njoin('./test/assets', 'foo.json'));
+    expect(files).to.include(njoin('./test/assets', 'z.txt'));
   });
   it('exclude files from array', () => {
     const files = getFiles(assetsPath, ['a.txt', 'b.txt']);
     expect(files).to.have.length(5);
-    expect(files).to.not.include(`${assetsPath}/a.txt`);
-    expect(files).to.not.include(`${assetsPath}/b.txt`);
+    expect(files).to.not.include(njoin(assetsPath, 'a.txt'));
+    expect(files).to.not.include(njoin(assetsPath, 'b.txt'));
   });
   it('exclude relative files from array', () => {
     const files = getFiles(assetsPath, ['./a.txt', './b.txt']);
     expect(files).to.have.length(5);
-    expect(files).to.not.include(`${assetsPath}/a.txt`);
-    expect(files).to.not.include(`${assetsPath}/b.txt`);
+    expect(files).to.not.include(njoin(assetsPath, 'a.txt'));
+    expect(files).to.not.include(njoin(assetsPath, 'b.txt'));
   });
   it('exclude files from glob', () => {
     const files = getFiles(assetsPath, ['folder/**/*.txt']);
     expect(files).to.have.length(5);
-    expect(files).to.not.include(`${assetsPath}/folder/p.txt`);
-    expect(files).to.not.include(`${assetsPath}/folder/q.txt`);
-    expect(files).to.include(`${assetsPath}/a.txt`);
-    expect(files).to.include(`${assetsPath}/b.txt`);
-    expect(files).to.include(`${assetsPath}/bundle.js`);
-    expect(files).to.include(`${assetsPath}/foo.json`);
-    expect(files).to.include(`${assetsPath}/z.txt`);
+    expect(files).to.not.include(path.join(assetsPath, 'folder/p.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'folder/q.txt'));
+    expect(files).to.include(path.join(assetsPath, 'a.txt'));
+    expect(files).to.include(path.join(assetsPath, 'b.txt'));
+    expect(files).to.include(path.join(assetsPath, 'bundle.js'));
+    expect(files).to.include(path.join(assetsPath, 'foo.json'));
+    expect(files).to.include(path.join(assetsPath, 'z.txt'));
   });
 });


### PR DESCRIPTION
It was discovered that getFiles() does not handle Windows paths very well. This
patch addresses the issue by:

1. Ensuring the tests are cross-platform themselves
2. All input and output paths are properly normalized by using
  `path.normalize()` and `path.join()`.

Issue originally reported in #24 

NOTE: I haven't had a chance to test this on a non-Windows computer yet.

Signed-off-by: Hajime Yamasaki Vukelic <hayavuk@gmail.com>