### PR TITLE
getFiles: fix handling fromPath

### DIFF
--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -3,14 +3,11 @@ import minimatch from 'minimatch';
 import path from 'path';
 
 export default function getFiles(fromPath, exclude = []) {
-  const npath = path.normalize(fromPath);
-  const files = recursiveReadSync(npath)
-    .map(p => p.substr(npath.length + 1)) // get files relative to fromPath
+  const files = recursiveReadSync(fromPath)
     .filter(file =>
       exclude.every(excluded =>
-        !minimatch(file, path.join(excluded), { dot: true }),
+        !minimatch(path.relative(fromPath, file), path.join(excluded), { dot: true }),
       ),
-    )
-    .map(file => path.join(npath, file));
+    );
   return files;
 }

--- a/test/getFiles.js
+++ b/test/getFiles.js
@@ -18,6 +18,14 @@ describe('getFiles', () => {
     expect(files).to.include(njoin(assetsPath, 'foo.json'));
     expect(files).to.include(njoin(assetsPath, 'z.txt'));
   });
+  it('handles trailing slash correctly', () => {
+    const files = getFiles(assetsPath + '/');
+    expect(files).to.include(njoin(assetsPath, 'folder/p.txt'));
+  });
+  it('handles relative paths', () => {
+    const files = getFiles('./test/assets');
+    expect(files).to.include('test/assets/folder/p.txt');
+  });
   it('get recursively the files in the relative path using POSIX separator', () => {
     const files = getFiles('./test/assets');
     expect(files).to.have.length(7);


### PR DESCRIPTION
This PR supersedes #23. @gpbl, feel free to tell me what's to be amended.

Actually, "it handles relative paths" test passes without this PR. But it was failing before #25.