### PR TITLE
Add 'cleanupOnlyLastBuild' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Added **`selfOnly`** option
+
 ## [v0.5.1](https://github.com/gpbl/webpack-cleanup-plugin/tree/v0.5.1) (2017-02-27)
 
 * Add support for relative output paths ([#23](https://github.com/gpbl/webpack-cleanup-plugin/pull/23) by [bassarisse](https://github.com/bassarisse), [#28](https://github.com/gpbl/webpack-cleanup-plugin/pull/28) by [x-yuri](https://github.com/x-yuri) and [#29](https://github.com/gpbl/webpack-cleanup-plugin/pull/29) by [foxbunny](https://github.com/foxbunny)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Added **`selfOnly`** option
+* Added **`cleanupOnlyLastBuild`** option
 
 ## [v0.5.1](https://github.com/gpbl/webpack-cleanup-plugin/tree/v0.5.1) (2017-02-27)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ new WebpackCleanupPlugin({
 })
 ```
 
+* To only remove file assets created directly by current Webpack build, use the **`selfOnly`** option:
+
+```js
+new WebpackCleanupPlugin({
+  selfOnly: true,
+})
+```
+
 * To mute the console output, use the **`quiet`** option:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ new WebpackCleanupPlugin({
 })
 ```
 
-* To only remove file assets created directly by current Webpack build, use the **`selfOnly`** option:
+* To only remove file assets created directly by current Webpack build, use the **`cleanupOnlyLastBuild`** option:
 
 ```js
 new WebpackCleanupPlugin({
-  selfOnly: true,
+  cleanupOnlyLastBuild: true,
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "webpack": "^2.2.1"
   },
   "dependencies": {
+    "lodash.includes": "4.3.0",
     "lodash.union": "4.6.0",
     "minimatch": "3.0.3",
     "recursive-readdir-sync": "1.0.6"

--- a/src/WebpackCleanupPlugin.js
+++ b/src/WebpackCleanupPlugin.js
@@ -25,7 +25,7 @@ class WebpackCleanupPlugin {
       const exclude = union(this.options.exclude, assets);
 
       let include;
-      if (this.options.selfOnly) {
+      if (this.options.cleanupOnlyLastBuild) {
         /**
          * Only include files that were in the previous build
          */

--- a/src/getFiles.js
+++ b/src/getFiles.js
@@ -2,12 +2,29 @@ import recursiveReadSync from 'recursive-readdir-sync';
 import minimatch from 'minimatch';
 import path from 'path';
 
-export default function getFiles(fromPath, exclude = []) {
-  const files = recursiveReadSync(fromPath)
-    .filter(file =>
-      exclude.every(excluded =>
-        !minimatch(path.relative(fromPath, file), path.join(excluded), { dot: true }),
-      ),
+export default function getFiles(fromPath, exclude = [], include /* : ?Array<string> */) {
+  const files = recursiveReadSync(fromPath).filter((file) => {
+    /**
+     * If 'include' is undefined, include all files
+     */
+    if (include) {
+      const isIncluded = include.some(included =>
+        minimatch(path.relative(fromPath, file), path.join(included), {
+          dot: true,
+        }),
+      );
+
+      if (!isIncluded) {
+        return false;
+      }
+    }
+
+    return exclude.every(
+      excluded =>
+        !minimatch(path.relative(fromPath, file), path.join(excluded), {
+          dot: true,
+        }),
     );
+  });
   return files;
 }

--- a/test/WebpackCleanupPlugin.js
+++ b/test/WebpackCleanupPlugin.js
@@ -57,5 +57,35 @@ describe('WebpackCleanupPlugin', () => {
         done();
       });
     });
+
+    it('should only delete files created by webpack', (done) => {
+      const webpackCleanupPlugin = new WebpackCleanupPlugin({ selfOnly: true, quiet: true });
+      const compiler = webpack({
+        ...webpackConfig,
+        output: {
+          path: outputPath,
+          filename: 'bundle.js',
+        },
+        plugins: [webpackCleanupPlugin],
+      });
+
+      /**
+       * mock the previous build's assets
+       */
+      webpackCleanupPlugin.previousAssets = ['bundle.js', 'a.txt', 'folder/q.txt'];
+
+      compiler.run(() => {
+        expect(webpackCleanupPlugin.previousAssets).to.deep.equal(['bundle.js']);
+        expect(unlinkSync).to.have.been.calledWith(njoin(outputPath, 'a.txt'));
+        expect(unlinkSync).to.have.been.calledWith(njoin(outputPath, 'folder/q.txt'));
+
+        expect(unlinkSync).to.not.have.been.calledWith(njoin(outputPath, 'folder/p.txt'));
+        expect(unlinkSync).to.not.have.been.calledWith(njoin(outputPath, 'b.txt'));
+        expect(unlinkSync).to.not.have.been.calledWith(njoin(outputPath, 'bundle.js'));
+        expect(unlinkSync).to.not.have.been.calledWith(njoin(outputPath, 'foo.json'));
+        expect(unlinkSync).to.not.have.been.calledWith(njoin(outputPath, 'z.txt'));
+        done();
+      });
+    });
   });
 });

--- a/test/WebpackCleanupPlugin.js
+++ b/test/WebpackCleanupPlugin.js
@@ -59,7 +59,10 @@ describe('WebpackCleanupPlugin', () => {
     });
 
     it('should only delete files created by webpack', (done) => {
-      const webpackCleanupPlugin = new WebpackCleanupPlugin({ selfOnly: true, quiet: true });
+      const webpackCleanupPlugin = new WebpackCleanupPlugin({
+        cleanupOnlyLastBuild: true,
+        quiet: true,
+      });
       const compiler = webpack({
         ...webpackConfig,
         output: {

--- a/test/getFiles.js
+++ b/test/getFiles.js
@@ -60,4 +60,37 @@ describe('getFiles', () => {
     expect(files).to.include(path.join(assetsPath, 'foo.json'));
     expect(files).to.include(path.join(assetsPath, 'z.txt'));
   });
+
+  it('only look at includes', () => {
+    const include = ['bundle.js', 'folder/p.txt'];
+
+    const files = getFiles(assetsPath, [], include);
+
+    expect(files).to.have.length(2);
+    expect(files).to.include(path.join(assetsPath, 'bundle.js'));
+    expect(files).to.include(path.join(assetsPath, 'folder/p.txt'));
+
+    expect(files).to.not.include(path.join(assetsPath, 'folder/q.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'a.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'b.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'foo.json'));
+    expect(files).to.not.include(path.join(assetsPath, 'z.txt'));
+  });
+
+  it('only look at includes but respects excludes', () => {
+    const include = ['bundle.js', 'folder/p.txt'];
+
+    const files = getFiles(assetsPath, ['folder/**/*.txt'], include);
+
+    expect(files).to.have.length(1);
+    expect(files).to.include(path.join(assetsPath, 'bundle.js'));
+
+    expect(files).to.not.include(path.join(assetsPath, 'folder/p.txt'));
+
+    expect(files).to.not.include(path.join(assetsPath, 'folder/q.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'a.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'b.txt'));
+    expect(files).to.not.include(path.join(assetsPath, 'foo.json'));
+    expect(files).to.not.include(path.join(assetsPath, 'z.txt'));
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,13 +376,7 @@ babel-helpers@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.23.0"
 
-babel-messages@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.22.0.tgz#36066a214f1217e4ed4164867669ecb39e3ea575"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-messages@^6.23.0:
+babel-messages@^6.22.0, babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
@@ -763,17 +757,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.22.0.tgz#403d110905a4626b317a2a1fcb8f3b73204b2edb"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.22.0"
-    babel-types "^6.22.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.23.0:
+babel-template@^6.22.0, babel-template@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
   dependencies:
@@ -783,21 +767,7 @@ babel-template@^6.23.0:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.15.0, babel-traverse@^6.22.0:
-  version "6.22.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.22.1.tgz#3b95cd6b7427d6f1f757704908f2fc9748a5f59f"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.22.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.22.0"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.23.0, babel-traverse@^6.23.1:
+babel-traverse@^6.15.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
   dependencies:
@@ -811,16 +781,7 @@ babel-traverse@^6.23.0, babel-traverse@^6.23.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.15.0, babel-types@^6.19.0, babel-types@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.22.0.tgz#2a447e8d0ea25d2512409e4175479fd78cc8b1db"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.23.0:
+babel-types@^6.15.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
   dependencies:
@@ -2238,6 +2199,10 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.includes@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -2887,15 +2852,15 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@~2.5.1, rimraf@~2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+rimraf@2, rimraf@^2.2.8, rimraf@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.2.8, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+rimraf@~2.5.1, rimraf@~2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
 


### PR DESCRIPTION
This adds a ``selfOnly`` option that will only remove files that the current Webpack compilation has created.

Can be used in combination or as an alternative to ``exclude``.